### PR TITLE
Drop support for secondary tables as model objects

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -52,13 +52,13 @@ jobs:
       - name: Set pythonpath
         run: echo "PYTHONPATH=$PWD" >> $GITHUB_ENV
       - name: Test
-        if: matrix.python-version != '3.11'
+        if: matrix.python-version != '3.12'
         run: poetry run pytest
       - name: Test with Coverage
-        if: matrix.python-version == '3.11'
+        if: matrix.python-version == '3.12'
         run: poetry run pytest examples tests --cov=sqlalchemy_flattener --cov-report=xml
       - uses: actions/upload-artifact@v3
-        if: matrix.python-version == '3.11'
+        if: matrix.python-version == '3.12'
         with:
           name: coverage-xml
           path: coverage.xml

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,10 +8,10 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
-      - name: Set up python 3.11
+      - name: Set up python 3.12
         uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: Install Poetry
         uses: snok/install-poetry@v1
       - name: Install dependencies

--- a/examples/models.py
+++ b/examples/models.py
@@ -5,7 +5,7 @@ from enum import Enum
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import DateTime, ForeignKey, Text, Uuid
+from sqlalchemy import Column, DateTime, ForeignKey, Table, Text, Uuid
 from sqlalchemy import Enum as SQLEnum
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
@@ -47,7 +47,13 @@ class BankDetails(Base):
 class Category(Base):
     __tablename__ = "category"
 
-    name: Mapped[str] = mapped_column(Text(), nullable=False)
+    name: Mapped[str] = mapped_column(Text())
+
+
+class Tag(Base):
+    __tablename__ = "tag"
+
+    name: Mapped[str] = mapped_column(Text())
 
 
 class Contact(Base):
@@ -89,15 +95,32 @@ class Supplier(Base):
     contacts: Mapped[list[Contact]] = relationship(
         lazy="noload", back_populates="supplier"
     )
+    tags: Mapped[list[Tag]] = relationship(lazy="noload", secondary="supplier_tag")
 
 
-class SupplierCategory(Base):
-    """Supplier to category association table."""
+supplier_category_association = Table(
+    "supplier_category",
+    Base.metadata,
+    Column("supplier_id", Uuid(), ForeignKey("supplier.id"), primary_key=True),
+    Column("category_id", Uuid(), ForeignKey("category.id"), primary_key=True),
+)
 
-    __tablename__ = "supplier_category"
 
-    supplier_id: Mapped[UUID] = mapped_column(Uuid(), ForeignKey("supplier.id"))
-    category_id: Mapped[UUID] = mapped_column(Uuid(), ForeignKey("category.id"))
+supplier_tag_association = Table(
+    "supplier_tag",
+    Base.metadata,
+    Column("supplier_id", Uuid(), ForeignKey("supplier.id"), primary_key=True),
+    Column("tag_id", Uuid(), ForeignKey("tag.id"), primary_key=True),
+)
 
 
-INSERT_ORDER = [Address, BankDetails, Category, Supplier, SupplierCategory, Contact]
+INSERT_ORDER = [
+    Address,
+    BankDetails,
+    Category,
+    Supplier,
+    Contact,
+    Tag,
+    supplier_category_association,
+    supplier_tag_association,
+]

--- a/examples/script.py
+++ b/examples/script.py
@@ -1,8 +1,9 @@
-from sqlalchemy_flattener import flatten, write_raw, write_sql
-
+from sqlalchemy_flattener import SQLAlchemyFlattener
+from sqlalchemy_flattener.writers import write_as_dict, write_as_sql
 from .instances import nested_supplier
 
 if __name__ == "__main__":
-    data = flatten(nested_supplier)
-    write_raw(data, "raw_dict.py")
-    write_sql(data, "raw.sql")
+    flattener = SQLAlchemyFlattener()
+    data = flattener.flatten(nested_supplier)
+    write_as_dict(data, "raw_dict.py")
+    write_as_sql(data, "raw.sql")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sqlalchemy-flattener"
-version = "0.3.4"
+version = "0.4.0"
 description = "Flatten SQLAlchemy model trees to raw data"
 authors = ["Michael Bosch <michael@lonelyviking.com>"]
 license = "MIT"

--- a/sqlalchemy_flattener/__main__.py
+++ b/sqlalchemy_flattener/__main__.py
@@ -4,6 +4,8 @@ import sys
 from collections.abc import Callable
 from pathlib import Path
 
+from sqlalchemy import Table
+
 from sqlalchemy_flattener.flattener import SQLAlchemyFlattener
 from sqlalchemy_flattener.writers import write_as_dict, write_as_sql
 
@@ -49,11 +51,11 @@ def main() -> None:
     flattener = SQLAlchemyFlattener()
     unordered_data = flattener.flatten(instances)
 
-    ordered_mapping = {
-        model.__table__: data
-        for model in order
-        if (data := unordered_data.get(model.__table__)) is not None
-    }
+    ordered_mapping = {}
+    for obj in order:
+        attr = obj if isinstance(obj, Table) else obj.__table__
+        if data := unordered_data.get(attr):
+            ordered_mapping[attr] = data
 
     if args.format == "dict":
         write_as_dict(ordered_mapping, args.output)

--- a/sqlalchemy_flattener/flattener.py
+++ b/sqlalchemy_flattener/flattener.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from datetime import date
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Literal
-from uuid import UUID, uuid4
+from uuid import UUID
 
 from sqlalchemy import inspect
 from sqlalchemy.orm import KeyFuncDict
@@ -24,7 +24,6 @@ class SQLAlchemyFlattener:
         serialize_uuids: bool = True,
         serialize_dates: bool = True,
         use_enum_values: bool = True,
-        generate_secondary_id: bool = True,
     ) -> None:
         """Initialize a flattener instance.
 
@@ -34,14 +33,12 @@ class SQLAlchemyFlattener:
             serialize_uuids: Whether to serialize UUIDs to strings.
             serialize_dates: Whether to serialize dates to strings.
             use_enum_values: Whether to use enum values instead of enum names.
-            generate_secondary_id: Whether to generate a primary key ID for secondary tables.
         """
         self.id_attribute_name = id_attribute_name
         self.id_attribute_type = id_attribute_type
         self.serialize_uuids = serialize_uuids
         self.serialize_dates = serialize_dates
         self.use_enum_values = use_enum_values
-        self.generate_secondary_id = generate_secondary_id
 
     def flatten(
         self,
@@ -131,10 +128,6 @@ class SQLAlchemyFlattener:
             )
             if self.serialize_uuids and isinstance(secondary_dict[column.name], UUID):
                 secondary_dict[column.name] = str(secondary_dict[column.name])
-        if self.generate_secondary_id:
-            secondary_dict[self.id_attribute_name] = (
-                str(uuid4()) if self.serialize_uuids else uuid4()
-            )
 
         return secondary_dict
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from examples.models import (
     Category,
     Contact,
     Supplier,
+    Tag,
 )
 
 
@@ -62,6 +63,7 @@ def suppliers(categories: list[Category]) -> tuple[Supplier]:
                     ),
                 ),
             ],
+            tags=[Tag(id=UUID("0a9406c6-c8f2-483b-a78b-46813374c00f"), name="depth")],
         ),
         Supplier(
             id=UUID("8f4f00f7-3352-4579-84ef-e2f8a455afc3"),

--- a/tests/test_flattening.py
+++ b/tests/test_flattening.py
@@ -1,14 +1,13 @@
 from __future__ import annotations
 
-from unittest.mock import ANY
-
 from examples.models import (
     Address,
     BankDetails,
     Category,
     Contact,
     Supplier,
-    SupplierCategory,
+    supplier_category_association,
+    supplier_tag_association,
 )
 from sqlalchemy_flattener import SQLAlchemyFlattener
 
@@ -77,32 +76,29 @@ def test_flatten_model_instance(suppliers: Supplier) -> None:
             {"name": "ISP", "id": "f66c3eb7-7b93-4d9f-bc66-8ff07353f5e7"},
         ]
     )
-    assert len(data[SupplierCategory.__table__]) == 4
+    assert len(data[supplier_category_association]) == 4
     assert all(
-        d in data[SupplierCategory.__table__]
+        d in data[supplier_category_association]
         for d in [
             {
                 "supplier_id": "2b7e7211-d2c7-4eb4-8c14-05ed58c77473",
                 "category_id": "3674c73c-a967-493f-9a4b-5b70f78a5a99",
-                "id": ANY,
             },
             {
                 "supplier_id": "2b7e7211-d2c7-4eb4-8c14-05ed58c77473",
                 "category_id": "f66c3eb7-7b93-4d9f-bc66-8ff07353f5e7",
-                "id": ANY,
             },
             {
                 "supplier_id": "8f4f00f7-3352-4579-84ef-e2f8a455afc3",
                 "category_id": "3674c73c-a967-493f-9a4b-5b70f78a5a99",
-                "id": ANY,
             },
             {
                 "supplier_id": "8f4f00f7-3352-4579-84ef-e2f8a455afc3",
                 "category_id": "f66c3eb7-7b93-4d9f-bc66-8ff07353f5e7",
-                "id": ANY,
             },
         ]
     )
+    assert len(data[supplier_tag_association]) == 1
     assert all(
         d in data[Contact.__table__]
         for d in [
@@ -135,29 +131,25 @@ def test_dedupe_many_to_many(supplier_categories: list[Supplier]) -> None:
             {"name": "ISP", "id": "f66c3eb7-7b93-4d9f-bc66-8ff07353f5e7"},
         ]
     )
-    assert len(data[SupplierCategory.__table__]) == 4
+    assert len(data[supplier_category_association]) == 4
     assert all(
-        d in data[SupplierCategory.__table__]
+        d in data[supplier_category_association]
         for d in [
             {
                 "supplier_id": "330b18d4-5b92-49e5-b899-394dafd19e95",
                 "category_id": "3674c73c-a967-493f-9a4b-5b70f78a5a99",
-                "id": ANY,
             },
             {
                 "supplier_id": "330b18d4-5b92-49e5-b899-394dafd19e95",
                 "category_id": "f66c3eb7-7b93-4d9f-bc66-8ff07353f5e7",
-                "id": ANY,
             },
             {
                 "supplier_id": "ca8e7bb6-898f-47d4-98f8-e5b560ed364e",
                 "category_id": "3674c73c-a967-493f-9a4b-5b70f78a5a99",
-                "id": ANY,
             },
             {
                 "supplier_id": "ca8e7bb6-898f-47d4-98f8-e5b560ed364e",
                 "category_id": "f66c3eb7-7b93-4d9f-bc66-8ff07353f5e7",
-                "id": ANY,
             },
         ]
     )


### PR DESCRIPTION
Currently the secondary tables for many-to-many associations are being treated as models, which I believe is an anti-pattern.

Instead, support is added for `sqlalchemy.Table` definitions as secondary tables.

See the [sqlalchemy documentation](https://docs.sqlalchemy.org/en/20/orm/basic_relationships.html#many-to-many) for more info.