### PR TITLE
Don't include column properties

### DIFF
--- a/examples/models.py
+++ b/examples/models.py
@@ -5,9 +5,15 @@ from enum import Enum
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import Column, DateTime, ForeignKey, Table, Text, Uuid
+from sqlalchemy import Column, DateTime, ForeignKey, Table, Text, Uuid, func, select
 from sqlalchemy import Enum as SQLEnum
-from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+from sqlalchemy.orm import (
+    DeclarativeBase,
+    Mapped,
+    column_property,
+    mapped_column,
+    relationship,
+)
 
 
 class AccountType(str, Enum):
@@ -96,6 +102,10 @@ class Supplier(Base):
         lazy="noload", back_populates="supplier"
     )
     tags: Mapped[list[Tag]] = relationship(lazy="noload", secondary="supplier_tag")
+    # arbitrary column property
+    tag_count: Mapped[int] = column_property(
+        select(func.count(Tag.id)).scalar_subquery()
+    )
 
 
 supplier_category_association = Table(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sqlalchemy-flattener"
-version = "0.4.0"
+version = "0.4.1"
 description = "Flatten SQLAlchemy model trees to raw data"
 authors = ["Michael Bosch <michael@lonelyviking.com>"]
 license = "MIT"

--- a/sqlalchemy_flattener/flattener.py
+++ b/sqlalchemy_flattener/flattener.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from uuid import UUID
 
 from sqlalchemy import inspect
-from sqlalchemy.orm import KeyFuncDict
+from sqlalchemy.orm import KeyFuncDict, MappedSQLExpression
 
 if TYPE_CHECKING:
     from sqlalchemy import Table
@@ -149,6 +149,9 @@ class SQLAlchemyFlattener:
 
         mapping: dict[str, str | Enum | date | UUID] = {}
         for column in inspector.mapper.column_attrs:
+            # skip column properties etc.
+            if isinstance(column, MappedSQLExpression):
+                continue
             value = getattr(instance, column.key)
             if self.use_enum_values and isinstance(value, Enum):
                 mapping[column.expression.key] = value.value

--- a/tests/test_flattening.py
+++ b/tests/test_flattening.py
@@ -16,6 +16,9 @@ def test_flatten_model_instance(suppliers: Supplier) -> None:
     flattener = SQLAlchemyFlattener()
     data = flattener.flatten(suppliers)
 
+    # column properties should not be present
+    assert "tag_count" not in data[Supplier.__table__][0]
+
     assert all(
         d in data[Supplier.__table__]
         for d in [


### PR DESCRIPTION
This PR addresses a bug where column properties would be processed and end up in output, leading to inserts into nonexistent columns.